### PR TITLE
added ScrollCalendar.setDateRange()

### DIFF
--- a/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/ScrollCalendar.java
+++ b/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/ScrollCalendar.java
@@ -64,6 +64,7 @@ public class ScrollCalendar extends LinearLayoutCompat implements ResProvider, C
     private int firstDayOfWeek;
     private boolean showYearAlways;
     private boolean softLineBreaks;
+    private boolean addCurrentMonth;
 
     private final LegendItem[] legend = new LegendItem[7];
 
@@ -111,11 +112,19 @@ public class ScrollCalendar extends LinearLayoutCompat implements ResProvider, C
         dayStyle = typedArray.getResourceId(R.styleable.ScrollCalendar_dayStyle, 0);
         showYearAlways = typedArray.getBoolean(R.styleable.ScrollCalendar_showYearAlways, false);
         softLineBreaks = typedArray.getBoolean(R.styleable.ScrollCalendar_roundLineBreaks, true);
+        addCurrentMonth = typedArray.getBoolean(R.styleable.ScrollCalendar_addCurrentMonth, true);
+
         typedArray.recycle();
     }
 
     public void setOnDateClickListener(@Nullable final OnDateClickListener calendarCallback) {
         getAdapter().setOnDateClickListener(calendarCallback);
+    }
+
+    // make sure to style with
+    // scrollcalendar:addCurrentMonth="false"
+    public void setDateRange(@Nullable Calendar firstDate, @Nullable Calendar lastDate, boolean truncateFirstAndLastMonth) {
+        getAdapter().setDateRange(firstDate, lastDate, truncateFirstAndLastMonth);
     }
 
     @SuppressWarnings("unused")
@@ -209,12 +218,12 @@ public class ScrollCalendar extends LinearLayoutCompat implements ResProvider, C
 
         switch (defaultAdapter) {
             case 1:
-                return new DefaultDateScrollCalendarAdapter(monthResProvider, dayResProvider, this);
+                return new DefaultDateScrollCalendarAdapter(monthResProvider, dayResProvider, this, addCurrentMonth);
             case 2:
-                return new DefaultRangeScrollCalendarAdapter(monthResProvider, dayResProvider, this);
+                return new DefaultRangeScrollCalendarAdapter(monthResProvider, dayResProvider, this, addCurrentMonth);
             case 0:
             default:
-                return new ScrollCalendarAdapter(monthResProvider, dayResProvider, this);
+                return new ScrollCalendarAdapter(monthResProvider, dayResProvider, this, addCurrentMonth);
         }
     }
 

--- a/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/MonthViewHolder.java
+++ b/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/MonthViewHolder.java
@@ -34,7 +34,7 @@ public class MonthViewHolder extends RecyclerView.ViewHolder {
     private final View space;
     private MonthResProvider monthResProvider;
 
-    private final WeekHolder[] weeks = new WeekHolder[7];
+    private final WeekHolder[] weeks = new WeekHolder[6]; // max (partial) weeks in month
     private boolean textAllCaps;
     private CalendarProvider calendarProvider;
 
@@ -96,8 +96,8 @@ public class MonthViewHolder extends RecyclerView.ViewHolder {
             String txt = monthResProvider.showYearAlways() ? month.getMonthNameWithYear() : month.getReadableMonthName();
             title.setText(applyCase(txt));
         }
-        for (int i = 0; i <= weeks.length - 1; i++) {
-            weeks[i].display(i, month, filterWeekDays(i, month));
+        for (int i = 0; i < weeks.length; i++) {
+            weeks[i].display(i+1, month, filterWeekDays(i+1, month));
         }
     }
 

--- a/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/WeekHolder.java
+++ b/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/WeekHolder.java
@@ -7,6 +7,8 @@ import android.widget.LinearLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.Calendar;
+
 import pl.rafman.scrollcalendar.R;
 import pl.rafman.scrollcalendar.contract.ClickCallback;
 import pl.rafman.scrollcalendar.data.CalendarDay;
@@ -54,14 +56,23 @@ public class WeekHolder {
         for (int i = 0; i < days.length; i++) {
             days[i].display(
                     month,
-                    dayOrNull(i, week, daysOfWeek),
-                    dayOrNull(i - 1, week, daysOfWeek),
-                    dayOrNull(i + 1, week, daysOfWeek)
+                    dayOrNull(i, month, week, daysOfWeek),
+                    dayOrNull(i - 1, month, week, daysOfWeek),
+                    dayOrNull(i + 1, month, week, daysOfWeek)
             );
         }
     }
 
-    private CalendarDay dayOrNull(int position, int week, CalendarDay[] calendarDays) {
+    private CalendarDay dayOrNull(int position, CalendarMonth month, int week, CalendarDay[] calendarDays) {
+        // special case: week of startDate
+        Calendar firstDate = CalendarMonth.getFirstDate();
+        if (firstDate != null
+                && month.getYear() == firstDate.get(Calendar.YEAR) && month.getMonth() == firstDate.get(Calendar.MONTH)
+                && week == firstDate.get(Calendar.WEEK_OF_MONTH)) {
+            // force right aligned
+            return takeRightAligned(position, calendarDays);
+        }
+
         if (isRightAligned(week)) {
             return takeRightAligned(position, calendarDays);
         } else {

--- a/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/example/DefaultDateScrollCalendarAdapter.java
+++ b/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/example/DefaultDateScrollCalendarAdapter.java
@@ -24,6 +24,11 @@ public class DefaultDateScrollCalendarAdapter extends ScrollCalendarAdapter {
         this.calendarProvider = calendarProvider;
     }
 
+    public DefaultDateScrollCalendarAdapter(@NonNull MonthResProvider monthResProvider, @NonNull DayResProvider dayResProvider, CalendarProvider calendarProvider, boolean addCurrentMonth) {
+        super(monthResProvider, dayResProvider, calendarProvider, addCurrentMonth);
+        this.calendarProvider = calendarProvider;
+    }
+
     @Override
     protected void onCalendarDayClicked(int year, int month, int day) {
         Calendar calendar = calendarProvider.getCalendar();

--- a/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/example/DefaultRangeScrollCalendarAdapter.java
+++ b/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/adapter/example/DefaultRangeScrollCalendarAdapter.java
@@ -26,6 +26,11 @@ public class DefaultRangeScrollCalendarAdapter extends ScrollCalendarAdapter {
         this.calendarProvider = calendarProvider;
     }
 
+    public DefaultRangeScrollCalendarAdapter(@NonNull MonthResProvider monthResProvider, @NonNull DayResProvider dayResProvider, CalendarProvider calendarProvider, boolean addCurrentMonth) {
+        super(monthResProvider, dayResProvider, calendarProvider, addCurrentMonth);
+        this.calendarProvider = calendarProvider;
+    }
+
     @Override
     protected void onCalendarDayClicked(int year, int month, int day) {
         if (isInThePast(year, month, day)) {

--- a/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/data/CalendarMonth.java
+++ b/scrollcalendar/src/main/java/pl/rafman/scrollcalendar/data/CalendarMonth.java
@@ -1,6 +1,7 @@
 package pl.rafman.scrollcalendar.data;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.Serializable;
 import java.text.DateFormatSymbols;
@@ -20,6 +21,11 @@ public class CalendarMonth implements Serializable {
     @NonNull
     private final CalendarDay[] days;
     private final CalendarProvider calendarProvider;
+
+    @Nullable
+    private static Calendar firstDate;
+    @Nullable
+    private static Calendar lastDate;
 
     public CalendarMonth(CalendarProvider calendarProvider, int year, int month) {
         this(calendarProvider, year, month, makeDays(calendarProvider, year, month));
@@ -43,11 +49,21 @@ public class CalendarMonth implements Serializable {
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
 
-        int maxDays = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
-        CalendarDay[] calendarDays = new CalendarDay[maxDays];
+        int firstDay = 1;
+        if (firstDate != null && year == firstDate.get(Calendar.YEAR) && month == firstDate.get(Calendar.MONTH)) {
+            firstDay = firstDate.get(Calendar.DAY_OF_MONTH);
+        }
 
-        for (int i = 1; i <= maxDays; i++) {
-            calendarDays[i - 1] = new CalendarDay(i);
+        int lastDay = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+        if (lastDate != null && year == lastDate.get(Calendar.YEAR) && month == lastDate.get(Calendar.MONTH)) {
+            lastDay = lastDate.get(Calendar.DAY_OF_MONTH);
+        }
+
+        int days = lastDay - firstDay + 1;
+        CalendarDay[] calendarDays = new CalendarDay[days];
+
+        for (int day = 0; day < days; day++) {
+            calendarDays[day] = new CalendarDay(day + firstDay);
         }
 
         return calendarDays;
@@ -121,4 +137,16 @@ public class CalendarMonth implements Serializable {
     public String getMonthNameWithYear() {
         return getMonthForInt(getMonth()) + " " + year;
     }
+
+
+
+    public static void setDateRange(Calendar firstDate, Calendar lastDate) {
+        CalendarMonth.firstDate = firstDate;
+        CalendarMonth.lastDate = lastDate;
+    }
+
+    public static Calendar getFirstDate() { return firstDate; }
+
+    public static Calendar getLastDate() { return lastDate; }
+
 }

--- a/scrollcalendar/src/main/res/values/scrollcalendar_attrs.xml
+++ b/scrollcalendar/src/main/res/values/scrollcalendar_attrs.xml
@@ -19,6 +19,7 @@
         <attr name="endlessTop" format="boolean" />
         <attr name="showYearAlways" format="boolean" />
         <attr name="roundLineBreaks" format="boolean" />
+        <attr name="addCurrentMonth" format="boolean" />
         <!--adapter-->
         <attr name="adapter" format="enum">
             <enum name="none" value="0" />


### PR DESCRIPTION
I wasn't sure if the new constructors for ScrollCalendarAdapter, DefaultRangeScrollCalendarAdapter, and DefaultDateScrollCalendarAdapter should replace the current ones.

Is the addCurrentMonth attribute overkill? Is it fine to just add it automatically, and remove it if setDateRange() is called?

Idea for future improvement: explicitly specify the initial month.

